### PR TITLE
Fix Schedule Detail Confing preview

### DIFF
--- a/server/controllers/hme.js
+++ b/server/controllers/hme.js
@@ -110,7 +110,7 @@ exports.previewLedColor = async function (ctx) {
             ledData.devID = 0;
             let result = await new Promise((resolve, reject) => {
               request
-              .post(`http://${slave.host}:3000/rest/slave/${slave.id}/device/${device.id}/setLedDisplay`)
+              .post(`http://${slave.host}:3000/rest/slave/${slave.id}/device/0/setLedDisplay`)
               .send(ledData)
               .end((err, res) => {
                 if(err) return reject(err);
@@ -133,7 +133,7 @@ exports.previewLedColor = async function (ctx) {
           ledData.devID = 0;
           let result = await new Promise((resolve, reject) => {
             request
-            .post(`http://${slave.host}:3000/rest/slave/${schedule.SlaveId}/device/${device.id}/setLedDisplay`)
+            .post(`http://${slave.host}:3000/rest/slave/${schedule.SlaveId}/device/0/setLedDisplay`)
             .send(ledData)
             .end((err, res) => {
               if(err) return reject(err);

--- a/server/controllers/hme.js
+++ b/server/controllers/hme.js
@@ -106,9 +106,8 @@ exports.previewLedColor = async function (ctx) {
             SlaveId: slave.id
           }
         });
-        for(let device of devices){
           try {
-            ledData.devID = device.id;
+            ledData.devID = 0;
             let result = await new Promise((resolve, reject) => {
               request
               .post(`http://${slave.host}:3000/rest/slave/${slave.id}/device/${device.id}/setLedDisplay`)
@@ -121,7 +120,6 @@ exports.previewLedColor = async function (ctx) {
           } catch (e) {
             console.log(e);
           }
-        }
       }
     }else{
       let slave = await models.Slave.findById(schedule.SlaveId);
@@ -131,9 +129,8 @@ exports.previewLedColor = async function (ctx) {
         }
       })
       ledData.groupID = slave.id;
-      for(let device of devices){
         try {
-          ledData.devID = device.id;
+          ledData.devID = 0;
           let result = await new Promise((resolve, reject) => {
             request
             .post(`http://${slave.host}:3000/rest/slave/${schedule.SlaveId}/device/${device.id}/setLedDisplay`)
@@ -146,7 +143,6 @@ exports.previewLedColor = async function (ctx) {
         } catch (e) {
           console.log(e);
         }
-      }
     }
     ctx.body = 'ok'
   } catch (e) {

--- a/server/services/hme.js
+++ b/server/services/hme.js
@@ -548,7 +548,7 @@ export default class Hme {
       let CtrlModeTable = {'Normal':0, 'Fast':1, 'Interact':2};
       let accDevParams = {
         u8DevID:devID,
-        groupID:groupID,
+        groupID:0,
         sFunc:'WordWt',
         u8DataNum:1,
         u8Addr_Arry:[100],  //Device group
@@ -673,7 +673,7 @@ export default class Hme {
 
         let setParams = {
           devID:devID,
-          groupID:groupID,
+          groupID:0,
           Led1Bgt: DB * Bright,
           Led2Bgt: BL * Bright,
           Led3Bgt: RE * Bright,


### PR DESCRIPTION
在"Schedule Detail Confing"頁面中，操作拉霸時無法讓Device產生對應的亮度變化，經查為所產生的groupID與devID與實際不符。
因使用情境為廣播模式，故修正為groupID與devID均固定為0。
